### PR TITLE
Always last version of action in the code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Thu  05 May 2022  14:39:59 UTC
             uses: actions/checkout@v3
 
           - name: Update with Datetime of Workflow
-            uses: ZekeriyaAY/workflow-date@v1
+            uses: ZekeriyaAY/workflow-date@main
             with:
               github_token: ${{ secrets.GITHUB_TOKEN }}
               # date_format: '%a  %d %b %Y  %H:%M:%S%Z'


### PR DESCRIPTION
I had the dependency error, I couldn't figure out why, even if in your repository's code there was the right path to the requirements. Then I understood the copy-paste version oversight. Problem Solved 😉